### PR TITLE
Require only the aws-sdk-ssm gem

### DIFF
--- a/lib/ssm_env/client.rb
+++ b/lib/ssm_env/client.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 
 class Client
   def self.get_client(region: 'us-east-1', access_key_id: , secret_access_key: )

--- a/lib/ssm_env/fetcher.rb
+++ b/lib/ssm_env/fetcher.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 
 module SsmEnv
   class Fetcher

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ssm_env'
 require 'ostruct'
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 require 'byebug'

--- a/spec/ssm_env_spec.rb
+++ b/spec/ssm_env_spec.rb
@@ -45,7 +45,7 @@ describe SsmEnv do
     let(:client) { double(:client) }
     it 'creates a client with the correct config' do
       expect(Client).to receive(:get_client).with(config).and_return(client)
-      SsmEnv.client
+      SsmEnv.client(config[:access_key_id], config[:secret_access_key])
     end
   end
   context '.config' do

--- a/ssm_env.gemspec
+++ b/ssm_env.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'ssm_env'
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk", "~> 3.0"
+  spec.add_runtime_dependency "aws-sdk-ssm", "~> 1.41.0"
   spec.add_runtime_dependency "thor", "~> 1.1"
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Updating the `ssm_env` gem on a project causes the whole AWS SDK gem list to update, and currently installs more gems than previously installed - a lot more!

This PR changes the runtime requirements on the gemspec to only require the `aws-sdk-ssm` gem, and setting a soft version requirement of `~> 1.41`, matching the version currently on everlance api's `Gemfile.lock`
