### PR TITLE
reduce aws-sdk scope to only use aws-sdk-ssm

### DIFF
--- a/lib/ssm_env/client.rb
+++ b/lib/ssm_env/client.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 
 class Client
   def self.get_client(region: 'us-east-1', access_key_id: , secret_access_key: )

--- a/lib/ssm_env/fetcher.rb
+++ b/lib/ssm_env/fetcher.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 
 module SsmEnv
   class Fetcher

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ssm_env'
 require 'ostruct'
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 require 'byebug'

--- a/ssm_env.gemspec
+++ b/ssm_env.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'ssm_env'
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk-ssm", "~> 3.0"
+  spec.add_runtime_dependency "aws-sdk-ssm", "~> 1.148"
   spec.add_runtime_dependency "thor", "~> 1.1"
 
   spec.add_development_dependency "bundler", "~> 1.11"

--- a/ssm_env.gemspec
+++ b/ssm_env.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'ssm_env'
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk", "~> 3.0"
+  spec.add_runtime_dependency "aws-sdk-ssm", "~> 3.0"
   spec.add_runtime_dependency "thor", "~> 1.1"
 
   spec.add_development_dependency "bundler", "~> 1.11"

--- a/ssm_env.gemspec
+++ b/ssm_env.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "aws-sdk-ssm", "~> 1.148"
   spec.add_runtime_dependency "thor", "~> 1.1"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 2.4.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Noticed while attempting to use this for a packaged lambda that it was using the entire aws-sdk dependency tree.  Went through and validated only aws-sdk-ssm is being used here.

Made the changes to the gemspec as well as the file reqs as well.

Reduced the output Gemfile.lock length from 1406 lines to 53.  This will make packaged lambdas much smaller,  improve deployment times, and make dependency tracking clearer.

There was a failed test on Client init that took place before the changes I made were added and that same test still fails.  I believe the failure may be from changes that AWS has made to their libraries.