### PR TITLE
Relax runtime requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /spec/reports/
 /tmp/
 .idea/
+
+# Running the test suite generates this file:
+/test-env

--- a/lib/ssm_env.rb
+++ b/lib/ssm_env.rb
@@ -17,7 +17,7 @@ module SsmEnv
       ssm_params.each { |name, attribs| f << "#{name}=#{attribs[:value]}\n"}
     end
   end
-  def self.client(access_key_id, secret_access_key)
+  def self.client(access_key_id = nil, secret_access_key = nil)
     @client = Client.get_client(region:             SsmEnv.config.region,
                                 access_key_id:      access_key_id || SsmEnv.config.access_key_id,
                                 secret_access_key:  secret_access_key || SsmEnv.config.secret_access_key)

--- a/lib/ssm_env/client.rb
+++ b/lib/ssm_env/client.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 
 class Client
   def self.get_client(region: 'us-east-1', access_key_id: , secret_access_key: )

--- a/lib/ssm_env/fetcher.rb
+++ b/lib/ssm_env/fetcher.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 
 module SsmEnv
   class Fetcher

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ssm_env'
 require 'ostruct'
-require 'aws-sdk'
+require 'aws-sdk-ssm'
 require 'byebug'

--- a/ssm_env.gemspec
+++ b/ssm_env.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "aws-sdk-ssm", ">= 1.160.0"
-  spec.add_runtime_dependency "thor", "0.19.1"
+  spec.add_runtime_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/ssm_env.gemspec
+++ b/ssm_env.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'ssm_env'
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sdk", "~> 3.0"
+  spec.add_runtime_dependency "aws-sdk-ssm", ">= 1.160.0"
   spec.add_runtime_dependency "thor", "0.19.1"
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
On Everlance we can't upgrade to Rails 5 until we relax the `thor` runtime version requirement in this gem.

The changes in this PR remove the `thor` gem version runtime requirement, while also relax the `aws-sdk` requirement to just the `aws-sdk-ssm` gem.